### PR TITLE
Added LIVE_QUERY_CLASS_NAMES environment variable

### DIFF
--- a/app.json
+++ b/app.json
@@ -17,6 +17,10 @@
       "description": "A key that overrides all permissions. Keep this secret.",
       "value": "myMasterKey"
     },
+    "LIVE_QUERY_CLASS_NAMES": {
+      "description": "Comma-separated list of classes for query subscriptions",
+      "value": "Posts,Comments"
+    },
     "SERVER_URL": {
       "description": "URL to connect to your Heroku instance (update with your app's name + PARSE_MOUNT)",
       "value": "http://yourappname.herokuapp.com/parse"

--- a/app.yaml
+++ b/app.yaml
@@ -10,3 +10,4 @@ env_variables:
   # FILE_KEY: <your-file-key>
   # PARSE_MOUNT: /parse
   # CLOUD_CODE_MAIN:  
+  # LIVE_QUERY_CLASS_NAMES: Posts,Comments

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -39,6 +39,11 @@
       "minLength": 1,
       "defaultValue": "myAppId"
     },
+    "parseLiveQueryClassNames": {
+      "type": "string",
+      "minLength": 0,
+      "defaultValue": "Posts,Comments"
+    },
     "parseMasterKey": {
       "type": "string",
       "minLength": 1,
@@ -109,6 +114,10 @@
             {
             "name": "APP_ID",
             "value": "[parameters('parseAppId')]"
+            },
+            {
+            "name": "LIVE_QUERY_CLASS_NAMES",
+            "value": "[parameters('parseLiveQueryClassNames')]"
             },
             {
             "name": "MASTER_KEY",

--- a/index.js
+++ b/index.js
@@ -11,6 +11,8 @@ if (!databaseUri) {
   console.log('DATABASE_URI not specified, falling back to localhost.');
 }
 
+var liveQueryClassNames = ((process.env.LIVE_QUERY_CLASS_NAMES && process.env.LIVE_QUERY_CLASS_NAMES.length > 0) && process.env.LIVE_QUERY_CLASS_NAMES.split(','));
+
 var api = new ParseServer({
   databaseURI: databaseUri || 'mongodb://localhost:27017/dev',
   cloud: process.env.CLOUD_CODE_MAIN || __dirname + '/cloud/main.js',
@@ -18,7 +20,7 @@ var api = new ParseServer({
   masterKey: process.env.MASTER_KEY || '', //Add your master key here. Keep it secret!
   serverURL: process.env.SERVER_URL || 'http://localhost:1337/parse',  // Don't forget to change to https if needed
   liveQuery: {
-    classNames: ["Posts", "Comments"] // List of classes to support for query subscriptions
+    classNames: liveQueryClassNames ||  ["Posts", "Comments"] // List of classes to support for query subscriptions
   }
 });
 // Client-keys like the javascript key or the .NET key are not necessary with parse-server

--- a/scalingo.json
+++ b/scalingo.json
@@ -16,6 +16,10 @@
       "description": "A key that overrides all permissions. Keep this secret.",
       "value": ""
     },
+    "LIVE_QUERY_CLASS_NAMES": {
+      "description": "Comma-separated list of classes for query subscriptions",
+      "value": "Posts,Comments"
+    },
     "DATABASE_URI": {
       "description": "Connection string for your database.",
       "value": "$SCALINGO_MONGO_URL"


### PR DESCRIPTION
We use a single code base for our Parse Server's and we've recently started using Live Queries. Not being able to set them via environment variables, we've made this small change to the code. 

I'm not sure if this is the best approach to set them, but I thought I should send a PR.
