### PR TITLE
fix(cloud): just return a string

### DIFF
--- a/cloud/main.js
+++ b/cloud/main.js
@@ -1,4 +1,3 @@
-
 Parse.Cloud.define('hello', function(req, res) {
-  res.success('Hi');
+  return 'Hi';
 });


### PR DESCRIPTION
When I run the cloud function example under `http://localhost:1337/test` I get an error message ` {"code":141,"error":"res.success is not a function"}`. This fixes it.