### PR TITLE
README: Fix the Sponsors badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # parse-server-example
 
 [![Join The Conversation](https://img.shields.io/discourse/https/community.parseplatform.org/topics.svg)](https://community.parseplatform.org/c/parse-server)
-[![Backers on Open Collective](https://opencollective.com/parse-server/backers/badge.svg)][open-collective-link]
-[![Sponsors on Open Collective](https://opencollective.com/parse-server/sponsors/badge.svg)][open-collective-link]
+[![Backers on Open Collective](https://opencollective.com/parse-server/tiers/backers/badge.svg)][open-collective-link]
+[![Sponsors on Open Collective](https://opencollective.com/parse-server/tiers/sponsors/badge.svg)][open-collective-link]
 [![License][license-svg]][license-link]
 [![Twitter Follow](https://img.shields.io/twitter/follow/ParsePlatform.svg?label=Follow%20us%20on%20Twitter&style=social)](https://twitter.com/intent/follow?screen_name=ParsePlatform)
 


### PR DESCRIPTION
This PR repairs the OpenCollective Sponsor counter.

Update the link on the Backers badge, to the new URI structure, too.