### PR TITLE
Remove NodeCommand for AWS

### DIFF
--- a/.ebextensions/app.config
+++ b/.ebextensions/app.config
@@ -6,5 +6,3 @@ option_settings:
     DATABASE_URI: "ReplaceWithDatabaseURI"
     NODE_ENV: "production"
     SERVER_URL: "http://myappname.elasticbeanstalk.com/parse"
-  aws:elasticbeanstalk:container:nodejs:
-    NodeCommand: "npm start"


### PR DESCRIPTION
Related to [this community discussion](https://community.parseplatform.org/t/nodecommand-is-no-longer-used-on-aws-parse-server-example/727/2). 

It seems as though AWS no longer supports NoeCommand, and running a fresh example install throws "NodeCommand not found".

Not sure if this has any impact on previous deployments on AWS.