### PR TITLE
Change example to ES6 imports

### DIFF
--- a/cloud/main.js
+++ b/cloud/main.js
@@ -1,2 +1,2 @@
 // It is best practise to organize your cloud functions group into their own file. You can then import them in your main.js.
-require('./functions.js');
+import('./functions.js');

--- a/index.js
+++ b/index.js
@@ -1,9 +1,11 @@
 // Example express application adding the parse-server module to expose Parse
 // compatible API routes.
 
-const express = require('express');
-const ParseServer = require('parse-server').ParseServer;
-const path = require('path');
+import express from 'express';
+import { ParseServer } from 'parse-server';
+import path from 'path';
+import { createServer } from 'http';
+const __dirname = path.resolve();
 const args = process.argv || [];
 const test = args.some(arg => arg.includes('jasmine'));
 
@@ -12,9 +14,9 @@ const databaseUri = process.env.DATABASE_URI || process.env.MONGODB_URI;
 if (!databaseUri) {
   console.log('DATABASE_URI not specified, falling back to localhost.');
 }
-const config = {
+export const config = {
   databaseURI: databaseUri || 'mongodb://localhost:27017/dev',
-  cloud: process.env.CLOUD_CODE_MAIN || __dirname + '/cloud/main.js',
+  cloud: () => import(process.env.CLOUD_CODE_MAIN || './cloud/main.js'),
   appId: process.env.APP_ID || 'myAppId',
   masterKey: process.env.MASTER_KEY || '', //Add your master key here. Keep it secret!
   serverURL: process.env.SERVER_URL || 'http://localhost:1337/parse', // Don't forget to change to https if needed
@@ -26,7 +28,7 @@ const config = {
 // If you wish you require them, you can set them as options in the initialization above:
 // javascriptKey, restAPIKey, dotNetKey, clientKey
 
-const app = express();
+export const app = express();
 
 // Serve static assets from the /public folder
 app.use('/public', express.static(path.join(__dirname, '/public')));
@@ -51,15 +53,10 @@ app.get('/test', function (req, res) {
 
 const port = process.env.PORT || 1337;
 if (!test) {
-  const httpServer = require('http').createServer(app);
+  const httpServer = createServer(app);
   httpServer.listen(port, function () {
     console.log('parse-server-example running on port ' + port + '.');
   });
   // This will enable the Live Query real-time server
   ParseServer.createLiveQueryServer(httpServer);
 }
-
-module.exports = {
-  app,
-  config,
-};

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
   "license": "MIT",
   "dependencies": {
     "express": "4.17.1",
-    "kerberos": "1.1.4",
-    "parse": "2.19.0",
-    "parse-server": "4.5.0"
+    "kerberos": "1.1.6",
+    "parse": "3.3.0",
+    "parse-server": "4.10.3"
   },
   "scripts": {
     "start": "node index.js",
@@ -26,17 +26,18 @@
   "engines": {
     "node": ">=4.3"
   },
+  "type": "module",
   "devDependencies": {
     "babel-eslint": "10.1.0",
-    "babel-watch": "7.4.0",
-    "eslint": "7.19.0",
-    "eslint-config-standard": "16.0.2",
-    "eslint-plugin-import": "2.22.1",
+    "babel-watch": "7.5.0",
+    "eslint": "7.32.0",
+    "eslint-config-standard": "16.0.3",
+    "eslint-plugin-import": "2.24.2",
     "eslint-plugin-node": "11.1.0",
-    "eslint-plugin-promise": "4.2.1",
-    "jasmine": "3.6.4",
-    "mongodb-runner": "4.8.1",
+    "eslint-plugin-promise": "5.1.0",
+    "jasmine": "3.9.0",
+    "mongodb-runner": "4.8.3",
     "nyc": "15.1.0",
-    "prettier": "2.2.1"
+    "prettier": "2.3.2"
   }
 }

--- a/spec/helper.js
+++ b/spec/helper.js
@@ -1,8 +1,8 @@
-const Parse = require('parse/node');
+import Parse from 'parse';
 Parse.initialize('test');
 Parse.serverURL = 'http://localhost:30001/test';
 Parse.masterKey = 'test';
-const { startParseServer, stopParseServer, dropDB } = require('./utils/test-runner.js');
+import { startParseServer, stopParseServer, dropDB } from './utils/test-runner.js';
 beforeAll(async () => {
   await startParseServer();
 }, 100 * 60 * 2);

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -5,5 +5,6 @@
   ],
   "helpers": ["helper.js"],
   "stopSpecOnExpectationFailure": false,
-  "random": false
+  "random": false,
+  "jsLoader": "import"
 }

--- a/spec/utils/test-runner.js
+++ b/spec/utils/test-runner.js
@@ -1,10 +1,10 @@
-const http = require('http');
-const { ParseServer } = require('parse-server');
-const { config, app } = require('../../index.js');
-const Config = require('../../node_modules/parse-server/lib/Config');
+import http from 'http';
+import { ParseServer } from 'parse-server';
+import { config, app } from '../../index.js';
+import Config from '../../node_modules/parse-server/lib/Config.js';
 
-let parseServerState = {};
-const dropDB = async () => {
+export let parseServerState = {};
+export const dropDB = async () => {
   await Parse.User.logOut();
   const app = Config.get('test');
   return await app.database.deleteEverything(true);
@@ -15,7 +15,7 @@ const dropDB = async () => {
  * @param {Object} parseServerOptions Used for creating the `ParseServer`
  * @return {Promise} Runner state
  */
-async function startParseServer() {
+export async function startParseServer() {
   delete config.databaseAdapter;
   const parseServerOptions = Object.assign(config, {
     databaseURI: 'mongodb://localhost:27017/parse-test',
@@ -26,18 +26,19 @@ async function startParseServer() {
     mountPath: '/test',
     serverURL: `http://localhost:30001/test`,
     logLevel: 'error',
-    silent: true
+    silent: true,
   });
   const parseServer = new ParseServer(parseServerOptions);
   app.use(parseServerOptions.mountPath, parseServer);
   const httpServer = http.createServer(app);
-  await new Promise((resolve) => httpServer.listen(parseServerOptions.port, resolve));
+  await new Promise(resolve => httpServer.listen(parseServerOptions.port, resolve));
   Object.assign(parseServerState, {
     parseServer,
     httpServer,
     expressApp: app,
     parseServerOptions,
   });
+  await new Promise(resolve => setTimeout(resolve, 500));
   return parseServerOptions;
 }
 
@@ -45,15 +46,8 @@ async function startParseServer() {
  * Stops the ParseServer instance
  * @return {Promise}
  */
-async function stopParseServer() {
+export async function stopParseServer() {
   const { httpServer } = parseServerState;
-  await new Promise((resolve) => httpServer.close(resolve));
+  await new Promise(resolve => httpServer.close(resolve));
   parseServerState = {};
 }
-
-module.exports = {
-  dropDB,
-  startParseServer,
-  stopParseServer,
-  parseServerState,
-};


### PR DESCRIPTION
- Changes example project to use `import / export` instead of `require / module.exports`
- Bumps dependancies