### PR TITLE
ci: change ESLint options to use "error" and "warn" instead of numbers

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,16 +12,16 @@
     "rules": {
         "indent": ["error", 2, { "SwitchCase": 1 }],
         "linebreak-style": ["error", "unix"],
-        "no-trailing-spaces": 2,
-        "eol-last": 2,
+        "no-trailing-spaces": "error",
+        "eol-last": "error",
         "space-in-parens": ["error", "never"],
-        "no-multiple-empty-lines": 1,
+        "no-multiple-empty-lines": "warn",
         "prefer-const": "error",
         "space-infix-ops": "error",
         "no-useless-escape": "off",
         "require-atomic-updates": "off",
-        "no-var": 1,
-        "no-await-in-loop" : 1
+        "no-var": "warn",
+        "no-await-in-loop" : "warn"
     },
     "globals" : {
         "Parse" : true


### PR DESCRIPTION
Fixes #408.