### PR TITLE
feat: Run with latest Google App Engine Flex environment requirements

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,6 +1,10 @@
 runtime: nodejs
 env: flex
 
+runtime_config:
+  operating_system: "ubuntu22"
+  runtime_version: "18"
+
 env_variables:
   # --REQUIRED--
   DATABASE_URI: mongodb://localhost:27017/dev

--- a/index.js
+++ b/index.js
@@ -24,6 +24,8 @@ export const config = {
 
 export const app = express();
 
+app.set('trust proxy', true);
+
 // Serve static assets from the /public folder
 app.use('/public', express.static(path.join(__dirname, '/public')));
 


### PR DESCRIPTION
- GAE Flexible Environment > 18 Requires Runtime Config
- GAE handles https forwarding on the node balancer. Add proxy based on [this](https://cloud.google.com/appengine/docs/flexible/nodejs/runtime#newversions)

Closes: https://github.com/parse-community/parse-server-example/issues/455