### PR TITLE
refactor: Bump prettier from 3.8.1 to 3.8.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "mongodb-runner": "6.7.3",
         "nodemon": "3.1.14",
         "nyc": "18.0.0",
-        "prettier": "3.8.1",
+        "prettier": "3.8.2",
         "semantic-release": "25.0.3",
         "tsx": "4.21.0",
         "typescript": "6.0.2",
@@ -12486,10 +12486,11 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
-      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.2.tgz",
+      "integrity": "sha512-8c3mgTe0ASwWAJK+78dpviD+A8EqhndQPUBpNUIPt6+xWlIigCwfN01lWr9MAede4uqXGTEKeQWTvzb3vjia0Q==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -24005,9 +24006,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
-      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.2.tgz",
+      "integrity": "sha512-8c3mgTe0ASwWAJK+78dpviD+A8EqhndQPUBpNUIPt6+xWlIigCwfN01lWr9MAede4uqXGTEKeQWTvzb3vjia0Q==",
       "dev": true
     },
     "pretty-ms": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "mongodb-runner": "6.7.3",
     "nodemon": "3.1.14",
     "nyc": "18.0.0",
-    "prettier": "3.8.1",
+    "prettier": "3.8.2",
     "semantic-release": "25.0.3",
     "tsx": "4.21.0",
     "typescript": "6.0.2",


### PR DESCRIPTION
## Changes

- Bumps [prettier](https://github.com/prettier/prettier) from 3.8.1 to 3.8.2 (devDependency, patch)

## Breaking Changes

- None

## Code Changes Required

- None

Closes #862

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated prettier code formatter to version 3.8.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->