### PR TITLE
fix: Restore Heroku deploy button setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,11 +101,13 @@ Configuration is located in `config.ts`.
 
 [![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
 
+The deploy button reads `app.json` and prompts for the required configuration. Heroku no longer offers the retired mLab add-on used by older versions of this example, so create a MongoDB database first and paste its connection string into `DATABASE_URI` when Heroku asks for config vars. After selecting your Heroku app name, update `SERVER_URL` to match it, for example `https://yourappname.herokuapp.com/parse`.
+
 Alternatively, to deploy manually:
 
 * Clone the repo and change directory to it
 * Log in with the [Heroku Toolbelt](https://toolbelt.heroku.com/) and create an app: `heroku create`
-* Use the [mLab addon](https://elements.heroku.com/addons/mongolab): `heroku addons:create mongolab:sandbox --app YourAppName`
+* Create a MongoDB database and set its connection string: `heroku config:set DATABASE_URI=<replace with MongoDB connection string> --app YourAppName`
 * By default it will use a path of /parse for the API routes.  To change this, or use older client SDKs, run `heroku config:set PARSE_MOUNT=/1`
 * Deploy it with: `git push heroku master`
 

--- a/app.json
+++ b/app.json
@@ -1,10 +1,14 @@
 {
   "name": "Parse Server Example",
   "description": "An example Parse API server using the parse-server module",
-  "repository": "https://github.com/ParsePlatform/parse-server-example",
+  "repository": "https://github.com/parse-community/parse-server-example",
   "logo": "https://avatars0.githubusercontent.com/u/1294580?v=3&s=200",
   "keywords": ["node", "express", "parse"],
   "env": {
+    "DATABASE_URI": {
+      "description": "MongoDB connection string for Parse Server. Create a MongoDB database before deploying and paste its connection string here.",
+      "required": true
+    },
     "PARSE_MOUNT": {
       "description": "Configure Parse API route.",
       "value": "/parse"
@@ -15,13 +19,11 @@
     },
     "MASTER_KEY": {
       "description": "A key that overrides all permissions. Keep this secret.",
-      "value": "myMasterKey"
+      "generator": "secret"
     },
     "SERVER_URL": {
-      "description": "URL to connect to your Heroku instance (update with your app's name + PARSE_MOUNT)",
-      "value": "http://yourappname.herokuapp.com/parse"
+      "description": "Public URL to connect to your Heroku instance. Update this after choosing the app name, for example: https://yourappname.herokuapp.com/parse",
+      "value": "https://yourappname.herokuapp.com/parse"
     }
-  },
-  "image": "heroku/nodejs",
-  "addons": ["mongolab"]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lint": "eslint --cache .",
     "lint-fix": "eslint --cache --fix .",
     "prettier": "prettier --write '{cloud,spec}/{**/*,*}.{ts,js,mjs,cjs}' index.ts",
+    "heroku-postbuild": "npm run build",
     "start": "node dist/index.js",
     "pretest": "cross-env MONGODB_VERSION=${MONGODB_VERSION:=7.0.1} MONGODB_TOPOLOGY=${MONGODB_TOPOLOGY:=standalone} mongodb-runner start -t ${MONGODB_TOPOLOGY} --version ${MONGODB_VERSION} -- --port 27017",
     "test": "TESTING=true tsx node_modules/jasmine/bin/jasmine",


### PR DESCRIPTION
Fixes #404.

This refreshes the Heroku quick-start path so the deploy button no longer depends on the retired mLab add-on and the app can build the TypeScript output that `npm start` expects.

Changes:
- add required `DATABASE_URI` prompt to `app.json`
- remove the retired `mongolab` add-on and deprecated `image` key from `app.json`
- update the repository URL and `SERVER_URL` example to current HTTPS values
- generate `MASTER_KEY` instead of shipping a fixed default
- add `heroku-postbuild` so Heroku builds `dist/` before running `node dist/index.js`
- update the README Heroku instructions to match the current setup flow

Verification:
- Parsed `app.json` and `package.json` with Node
- `git diff --check`

I did not create a live Heroku app from this environment, so this PR focuses on making the manifest and documented flow current and internally consistent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Heroku manual deployment guide to replace deprecated MongoDB add-on instructions with guidance for configuring custom MongoDB databases via connection string environment variables.

* **Chores**
  * Improved Heroku deployment configuration with mandatory database requirements, secure key generation, and automated build step execution during deployment.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/parse-community/parse-server-example/pull/885)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->