### PR TITLE
docs: Fix Heroku deploy button configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,14 +99,18 @@ Configuration is located in `config.ts`.
 
 ## Heroku
 
-[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
+[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy?template=https://github.com/parse-community/parse-server-example)
+
+The Heroku button uses `app.json` and asks for a `DATABASE_URI` during setup. Create a MongoDB database first, for example with [MongoDB Atlas](https://www.mongodb.com/atlas/database), then paste its connection string into the Heroku form.
 
 Alternatively, to deploy manually:
 
 * Clone the repo and change directory to it
-* Log in with the [Heroku Toolbelt](https://toolbelt.heroku.com/) and create an app: `heroku create`
-* Use the [mLab addon](https://elements.heroku.com/addons/mongolab): `heroku addons:create mongolab:sandbox --app YourAppName`
+* Log in with the [Heroku CLI](https://devcenter.heroku.com/articles/heroku-cli) and create an app: `heroku create`
+* Create a MongoDB database, for example with [MongoDB Atlas](https://www.mongodb.com/atlas/database), and copy its connection string
+* Configure the database connection: `heroku config:set DATABASE_URI='<replace with MongoDB connection string>'`
 * By default it will use a path of /parse for the API routes.  To change this, or use older client SDKs, run `heroku config:set PARSE_MOUNT=/1`
+* Configure the public server URL: `heroku config:set SERVER_URL=https://YourAppName.herokuapp.com/parse`
 * Deploy it with: `git push heroku master`
 
 ## AWS Elastic Beanstalk
@@ -135,10 +139,10 @@ Detailed information is available here:
 1. Install the [Google Cloud SDK](https://cloud.google.com/sdk/).
 1. Setup a MongoDB server.  You have a few options:
   1. Create a Google Compute Engine virtual machine with [MongoDB pre-installed](https://cloud.google.com/launcher/?q=mongodb).
-  1. Use [mLab](https://mlab.com/google/) to create a free MongoDB deployment on Google Cloud Platform (only US-central).
+  1. Use a hosted MongoDB service such as [MongoDB Atlas](https://www.mongodb.com/atlas/database).
 1. Modify `app.yaml` to update your environment variables.
 1. Delete `Dockerfile`
-1. Deploy it with `gcloud preview app deploy`
+1. Deploy it with `gcloud app deploy`
 
 A detailed tutorial is available here:
 [Running Parse server on Google App Engine](https://cloud.google.com/nodejs/resources/frameworks/parse-server)

--- a/README.md
+++ b/README.md
@@ -108,9 +108,9 @@ Alternatively, to deploy manually:
 * Clone the repo and change directory to it
 * Log in with the [Heroku CLI](https://devcenter.heroku.com/articles/heroku-cli) and create an app: `heroku create`
 * Create a MongoDB database, for example with [MongoDB Atlas](https://www.mongodb.com/atlas/database), and copy its connection string
-* Configure the database connection: `heroku config:set DATABASE_URI='<replace with MongoDB connection string>'`
+* Configure the database connection: `heroku config:set DATABASE_URI=<replace-with-mongodb-connection-string>`; quote or escape special characters as required by your shell.
 * By default it will use a path of /parse for the API routes.  To change this, or use older client SDKs, run `heroku config:set PARSE_MOUNT=/1`
-* Configure the public server URL: `heroku config:set SERVER_URL=https://YourAppName.herokuapp.com/parse`
+* Configure the public server URL with the same mount path: `heroku config:set SERVER_URL=https://YourAppName.herokuapp.com/parse` or `heroku config:set SERVER_URL=https://YourAppName.herokuapp.com/1`
 * Deploy it with: `git push heroku master`
 
 ## AWS Elastic Beanstalk

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "name": "Parse Server Example",
   "description": "An example Parse API server using the parse-server module",
-  "repository": "https://github.com/ParsePlatform/parse-server-example",
+  "repository": "https://github.com/parse-community/parse-server-example",
   "logo": "https://avatars0.githubusercontent.com/u/1294580?v=3&s=200",
   "keywords": ["node", "express", "parse"],
   "env": {
@@ -17,11 +17,14 @@
       "description": "A key that overrides all permissions. Keep this secret.",
       "value": "myMasterKey"
     },
+    "DATABASE_URI": {
+      "description": "MongoDB connection string for this Parse Server deployment, for example a MongoDB Atlas connection string.",
+      "required": true
+    },
     "SERVER_URL": {
-      "description": "URL to connect to your Heroku instance (update with your app's name + PARSE_MOUNT)",
-      "value": "http://yourappname.herokuapp.com/parse"
+      "description": "URL to connect to your Heroku instance (update with your app's name + PARSE_MOUNT).",
+      "value": "https://yourappname.herokuapp.com/parse"
     }
   },
-  "image": "heroku/nodejs",
-  "addons": ["mongolab"]
+  "image": "heroku/nodejs"
 }

--- a/app.json
+++ b/app.json
@@ -18,7 +18,7 @@
       "value": "myMasterKey"
     },
     "DATABASE_URI": {
-      "description": "MongoDB connection string for this Parse Server deployment, for example a MongoDB Atlas connection string.",
+      "description": "MongoDB connection string for this Parse Server deployment, for example a MongoDB Atlas connection string. Keep this secret because it can contain credentials.",
       "required": true
     },
     "SERVER_URL": {


### PR DESCRIPTION
## Summary
- update the quick-start Heroku deployment configuration
- align the README deployment button with the app.json setup
- refresh the app metadata and required environment variable prompts

Fixes #404

## Verification
- JSON validation for `app.json`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated deployment guides for Heroku and Google App Engine: replaced legacy mLab/mongolab instructions with MongoDB Atlas guidance, switched Heroku deploy button to a template-based URL, added steps to configure SERVER_URL, and updated App Engine deploy command.

* **Chores**
  * Updated project configuration to require DATABASE_URI, show an HTTPS SERVER_URL example, and remove obsolete add-on references.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/parse-community/parse-server-example/pull/889?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->