### PR TITLE
refactor: Bump parse-server from 9.8.0 to 9.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "express": "5.2.1",
         "parse": "8.5.0",
-        "parse-server": "9.8.0"
+        "parse-server": "9.9.0"
       },
       "devDependencies": {
         "@eslint/js": "10.0.1",
@@ -2830,40 +2830,6 @@
       },
       "engines": {
         "node": "20 || 22 || 24"
-      }
-    },
-    "node_modules/@parse/node-apn/node_modules/jsonwebtoken": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
-      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
-      "license": "MIT",
-      "dependencies": {
-        "jws": "^4.0.1",
-        "lodash.includes": "^4.3.0",
-        "lodash.isboolean": "^3.0.3",
-        "lodash.isinteger": "^4.0.4",
-        "lodash.isnumber": "^3.0.3",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.isstring": "^4.0.1",
-        "lodash.once": "^4.0.0",
-        "ms": "^2.1.1",
-        "semver": "^7.5.4"
-      },
-      "engines": {
-        "node": ">=12",
-        "npm": ">=6"
-      }
-    },
-    "node_modules/@parse/node-apn/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@parse/push-adapter": {
@@ -8456,12 +8422,12 @@
       }
     },
     "node_modules/jsonwebtoken": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
-      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
       "license": "MIT",
       "dependencies": {
-        "jws": "^3.2.2",
+        "jws": "^4.0.1",
         "lodash.includes": "^4.3.0",
         "lodash.isboolean": "^3.0.3",
         "lodash.isinteger": "^4.0.4",
@@ -8475,27 +8441,6 @@
       "engines": {
         "node": ">=12",
         "npm": ">=6"
-      }
-    },
-    "node_modules/jsonwebtoken/node_modules/jwa": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
-      "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-equal-constant-time": "^1.0.1",
-        "ecdsa-sig-formatter": "1.0.11",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/jsonwebtoken/node_modules/jws": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.3.tgz",
-      "integrity": "sha512-byiJ0FLRdLdSVSReO/U4E7RoEyOCKnEnEPMjq3HxWtvzLsV08/i5RQKsFVNkCldrCaPr2vDNAOMsfs8T/Hze7g==",
-      "license": "MIT",
-      "dependencies": {
-        "jwa": "^1.4.2",
-        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/jsonwebtoken/node_modules/semver": {
@@ -11906,9 +11851,9 @@
       }
     },
     "node_modules/parse-server": {
-      "version": "9.8.0",
-      "resolved": "https://registry.npmjs.org/parse-server/-/parse-server-9.8.0.tgz",
-      "integrity": "sha512-osUyuA2yqE5gBnmzcCvR3r9cEtZFNVglFufQsRG5pJaOJzb/+x1T5sbhdDvgE8C55hkhAKzLL2xFYPf1NPONWA==",
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/parse-server/-/parse-server-9.9.0.tgz",
+      "integrity": "sha512-r3MpxphR40G7Jgpb4H40ElXj4bEoC/5WNV3hqE13+XZG7ZLl6pATEzF6GjQwvM2421m2MHsvqGl34BxsVtURqg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -11931,7 +11876,7 @@
         "graphql-relay": "0.10.2",
         "graphql-upload": "15.0.2",
         "intersect": "1.0.1",
-        "jsonwebtoken": "9.0.2",
+        "jsonwebtoken": "9.0.3",
         "jwks-rsa": "3.2.0",
         "ldapjs": "3.0.7",
         "lodash": "4.18.1",
@@ -11940,8 +11885,8 @@
         "mongodb": "7.1.0",
         "mustache": "4.2.0",
         "otpauth": "9.5.0",
-        "parse": "8.5.0",
-        "path-to-regexp": "8.4.0",
+        "parse": "8.6.0",
+        "path-to-regexp": "8.4.2",
         "pg-monitor": "3.1.0",
         "pg-promise": "12.6.0",
         "pluralize": "8.0.0",
@@ -11958,7 +11903,7 @@
         "parse-server": "bin/parse-server"
       },
       "engines": {
-        "node": ">=20.19.0 <21.0.0 || >=22.12.0 <23.0.0 || >=24.11.0 <25.0.0"
+        "node": ">=20.19.0 <21.0.0 || >=22.13.0 <23.0.0 || >=24.11.0 <25.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -11966,6 +11911,27 @@
       },
       "optionalDependencies": {
         "@node-rs/bcrypt": "1.10.7"
+      }
+    },
+    "node_modules/parse-server/node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/parse-server/node_modules/@babel/runtime-corejs3": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.29.2.tgz",
+      "integrity": "sha512-Lc94FOD5+0aXhdb0Tdg3RUtqT6yWbI/BbFWvlaSJ3gAb9Ks+99nHRDKADVqC37er4eCB0fHyWT+y+K3QOvJKbw==",
+      "license": "MIT",
+      "dependencies": {
+        "core-js-pure": "^3.48.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/parse-server/node_modules/@types/whatwg-url": {
@@ -12096,6 +12062,23 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/parse-server/node_modules/parse": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/parse/-/parse-8.6.0.tgz",
+      "integrity": "sha512-AZjc8yGo8/iTZFpCXWw/r1qNusiUGWtq9i92/u0jNd+Iupg3EJUSV/OOyTrCeav8NDyo92wVS5O3iKAYPlhlsA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "7.29.2",
+        "@babel/runtime-corejs3": "7.29.2",
+        "crypto-js": "4.2.0",
+        "idb-keyval": "6.2.2",
+        "react-native-crypto-js": "1.0.0",
+        "ws": "8.20.0"
+      },
+      "engines": {
+        "node": ">=20.19.0 <21 || >=22.13.0 <23 || >=24.1.0 <25"
       }
     },
     "node_modules/parse-server/node_modules/semver": {
@@ -12255,9 +12238,10 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.0.tgz",
-      "integrity": "sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
@@ -17400,30 +17384,6 @@
         "jsonwebtoken": "9.0.3",
         "node-forge": "1.4.0",
         "verror": "1.10.1"
-      },
-      "dependencies": {
-        "jsonwebtoken": {
-          "version": "9.0.3",
-          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
-          "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
-          "requires": {
-            "jws": "^4.0.1",
-            "lodash.includes": "^4.3.0",
-            "lodash.isboolean": "^3.0.3",
-            "lodash.isinteger": "^4.0.4",
-            "lodash.isnumber": "^3.0.3",
-            "lodash.isplainobject": "^4.0.6",
-            "lodash.isstring": "^4.0.1",
-            "lodash.once": "^4.0.0",
-            "ms": "^2.1.1",
-            "semver": "^7.5.4"
-          }
-        },
-        "semver": {
-          "version": "7.7.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-          "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="
-        }
       }
     },
     "@parse/push-adapter": {
@@ -21369,11 +21329,11 @@
       }
     },
     "jsonwebtoken": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
-      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
       "requires": {
-        "jws": "^3.2.2",
+        "jws": "^4.0.1",
         "lodash.includes": "^4.3.0",
         "lodash.isboolean": "^3.0.3",
         "lodash.isinteger": "^4.0.4",
@@ -21385,25 +21345,6 @@
         "semver": "^7.5.4"
       },
       "dependencies": {
-        "jwa": {
-          "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
-          "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
-          "requires": {
-            "buffer-equal-constant-time": "^1.0.1",
-            "ecdsa-sig-formatter": "1.0.11",
-            "safe-buffer": "^5.0.1"
-          }
-        },
-        "jws": {
-          "version": "3.2.3",
-          "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.3.tgz",
-          "integrity": "sha512-byiJ0FLRdLdSVSReO/U4E7RoEyOCKnEnEPMjq3HxWtvzLsV08/i5RQKsFVNkCldrCaPr2vDNAOMsfs8T/Hze7g==",
-          "requires": {
-            "jwa": "^1.4.2",
-            "safe-buffer": "^5.0.1"
-          }
-        },
         "semver": {
           "version": "7.7.4",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
@@ -23703,9 +23644,9 @@
       "dev": true
     },
     "parse-server": {
-      "version": "9.8.0",
-      "resolved": "https://registry.npmjs.org/parse-server/-/parse-server-9.8.0.tgz",
-      "integrity": "sha512-osUyuA2yqE5gBnmzcCvR3r9cEtZFNVglFufQsRG5pJaOJzb/+x1T5sbhdDvgE8C55hkhAKzLL2xFYPf1NPONWA==",
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/parse-server/-/parse-server-9.9.0.tgz",
+      "integrity": "sha512-r3MpxphR40G7Jgpb4H40ElXj4bEoC/5WNV3hqE13+XZG7ZLl6pATEzF6GjQwvM2421m2MHsvqGl34BxsVtURqg==",
       "requires": {
         "@apollo/server": "5.5.0",
         "@as-integrations/express5": "1.1.2",
@@ -23727,7 +23668,7 @@
         "graphql-relay": "0.10.2",
         "graphql-upload": "15.0.2",
         "intersect": "1.0.1",
-        "jsonwebtoken": "9.0.2",
+        "jsonwebtoken": "9.0.3",
         "jwks-rsa": "3.2.0",
         "ldapjs": "3.0.7",
         "lodash": "4.18.1",
@@ -23736,8 +23677,8 @@
         "mongodb": "7.1.0",
         "mustache": "4.2.0",
         "otpauth": "9.5.0",
-        "parse": "8.5.0",
-        "path-to-regexp": "8.4.0",
+        "parse": "8.6.0",
+        "path-to-regexp": "8.4.2",
         "pg-monitor": "3.1.0",
         "pg-promise": "12.6.0",
         "pluralize": "8.0.0",
@@ -23751,6 +23692,19 @@
         "ws": "8.20.0"
       },
       "dependencies": {
+        "@babel/runtime": {
+          "version": "7.29.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+          "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="
+        },
+        "@babel/runtime-corejs3": {
+          "version": "7.29.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.29.2.tgz",
+          "integrity": "sha512-Lc94FOD5+0aXhdb0Tdg3RUtqT6yWbI/BbFWvlaSJ3gAb9Ks+99nHRDKADVqC37er4eCB0fHyWT+y+K3QOvJKbw==",
+          "requires": {
+            "core-js-pure": "^3.48.0"
+          }
+        },
         "@types/whatwg-url": {
           "version": "13.0.0",
           "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-13.0.0.tgz",
@@ -23822,6 +23776,19 @@
             "data-uri-to-buffer": "^4.0.0",
             "fetch-blob": "^3.1.4",
             "formdata-polyfill": "^4.0.10"
+          }
+        },
+        "parse": {
+          "version": "8.6.0",
+          "resolved": "https://registry.npmjs.org/parse/-/parse-8.6.0.tgz",
+          "integrity": "sha512-AZjc8yGo8/iTZFpCXWw/r1qNusiUGWtq9i92/u0jNd+Iupg3EJUSV/OOyTrCeav8NDyo92wVS5O3iKAYPlhlsA==",
+          "requires": {
+            "@babel/runtime": "7.29.2",
+            "@babel/runtime-corejs3": "7.29.2",
+            "crypto-js": "4.2.0",
+            "idb-keyval": "6.2.2",
+            "react-native-crypto-js": "1.0.0",
+            "ws": "8.20.0"
           }
         },
         "semver": {
@@ -23924,9 +23891,9 @@
       }
     },
     "path-to-regexp": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.0.tgz",
-      "integrity": "sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg=="
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="
     },
     "path-type": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "express": "5.2.1",
     "parse": "8.5.0",
-    "parse-server": "9.8.0"
+    "parse-server": "9.9.0"
   },
   "type": "module",
   "devDependencies": {


### PR DESCRIPTION
Bumps `parse-server` from 9.8.0 to 9.9.0.

Replacement for #883 (opens from a fork branch so CI secrets and status checks run). Closes #883.

### Changes
- `parse-server` 9.8.0 -> 9.9.0 (minor release; new aggregation `rawValues`/`rawFieldNames` options, installation deviceToken deduplication options, context-mutation and MFA fixes). See the [9.9.0 release notes](https://github.com/parse-community/parse-server/releases/tag/9.9.0).
- Version pinned exactly; `package-lock.json` regenerated (changes confined to the `parse-server` dependency subtree).

### Breaking Changes
None.

### Code Changes Required
None.
