### PR TITLE
refactor: Bump mongodb-runner from 6.7.7 to 6.8.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "eslint": "10.2.1",
         "globals": "17.5.0",
         "jasmine": "6.2.0",
-        "mongodb-runner": "6.7.7",
+        "mongodb-runner": "6.8.3",
         "nodemon": "3.1.14",
         "nyc": "18.0.0",
         "prettier": "3.8.3",
@@ -4058,13 +4058,14 @@
     "node_modules/@types/webidl-conversions": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
-      "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA=="
+      "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==",
+      "license": "MIT"
     },
     "node_modules/@types/whatwg-url": {
-      "version": "11.0.5",
-      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
-      "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
-      "dev": true,
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-13.0.0.tgz",
+      "integrity": "sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q==",
+      "license": "MIT",
       "dependencies": {
         "@types/webidl-conversions": "*"
       }
@@ -4817,12 +4818,12 @@
       }
     },
     "node_modules/bson": {
-      "version": "6.10.4",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.4.tgz",
-      "integrity": "sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng==",
-      "dev": true,
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-7.3.1.tgz",
+      "integrity": "sha512-h/C0qe6857pQhcSJHLfsR1uYGj98Ge3wKAD3Ed9KqH3wcVh+BM4Jq4xISD7vs9OPuT07n+q3QQVjslJ286j6ag==",
+      "license": "Apache-2.0",
       "engines": {
-        "node": ">=16.20.1"
+        "node": ">=20.19.0"
       }
     },
     "node_modules/buffer": {
@@ -7317,67 +7318,6 @@
         "uuid": "dist/bin/uuid"
       }
     },
-    "node_modules/gcp-metadata": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-5.3.0.tgz",
-      "integrity": "sha512-FNTkdNEnBdlqF2oatizolQqNANMrcqJt6AAYt99B3y1aLLC8Hc5IOBb+ZnnzllodEEf6xMBp6wRcBbc16fa65w==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "gaxios": "^5.0.0",
-        "json-bigint": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/gcp-metadata/node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/gcp-metadata/node_modules/gaxios": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-5.1.3.tgz",
-      "integrity": "sha512-95hVgBRgEIRQQQHIbnxBXeHbW4TqFk4ZDJW7wmVtvYar72FdhRIo1UGOLS2eRAKCPEdPBWu+M7+A33D9CdX9rA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "extend": "^3.0.2",
-        "https-proxy-agent": "^5.0.0",
-        "is-stream": "^2.0.0",
-        "node-fetch": "^2.6.9"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/gcp-metadata/node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -9203,26 +9143,27 @@
       }
     },
     "node_modules/mongodb": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.20.0.tgz",
-      "integrity": "sha512-Tl6MEIU3K4Rq3TSHd+sZQqRBoGlFsOgNrH5ltAcFBV62Re3Fd+FcaVf8uSEQFOJ51SDowDVttBTONMfoYWrWlQ==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-7.5.0.tgz",
+      "integrity": "sha512-5FnrEDLnvp6ycUOGLNLLU33BfCx2qmp2mJjGPDwKLruYsVzXVSK5fsGpoDXvsXJwBfBsD7ebMRdawbDxC2814g==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@mongodb-js/saslprep": "^1.3.0",
-        "bson": "^6.10.4",
-        "mongodb-connection-string-url": "^3.0.2"
+        "@mongodb-js/saslprep": "^1.4.11",
+        "bson": "^7.2.0",
+        "mongodb-connection-string-url": "^7.0.1"
       },
       "engines": {
-        "node": ">=16.20.1"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "@aws-sdk/credential-providers": "^3.188.0",
-        "@mongodb-js/zstd": "^1.1.0 || ^2.0.0",
-        "gcp-metadata": "^5.2.0",
-        "kerberos": "^2.0.1",
-        "mongodb-client-encryption": ">=6.0.0 <7",
+        "@aws-sdk/credential-providers": "^3.806.0",
+        "@mongodb-js/zstd": "^7.0.0",
+        "gcp-metadata": "^7.0.1",
+        "kerberos": "^7.0.0",
+        "mongodb-client-encryption": "^7.2.0",
         "snappy": "^7.3.2",
-        "socks": "^2.7.1"
+        "socks": "^2.8.6"
       },
       "peerDependenciesMeta": {
         "@aws-sdk/credential-providers": {
@@ -9249,47 +9190,50 @@
       }
     },
     "node_modules/mongodb-connection-string-url": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.2.tgz",
-      "integrity": "sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==",
-      "dev": true,
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-7.0.2.tgz",
+      "integrity": "sha512-ZoS07RoFqpKYQwAk59qmrx8+jJHNHU30UjlU96QktiGn1ltvDr+vCznLX5DiUBLEpMAHatHNWV1nM/74ul66kA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@types/whatwg-url": "^11.0.2",
-        "whatwg-url": "^14.1.0 || ^13.0.0"
+        "@types/whatwg-url": "^13.0.0",
+        "whatwg-url": "^14.1.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/mongodb-connection-string-url/node_modules/tr46": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
-      "integrity": "sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==",
-      "dev": true,
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "license": "MIT",
       "dependencies": {
-        "punycode": "^2.3.0"
+        "punycode": "^2.3.1"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/mongodb-connection-string-url/node_modules/webidl-conversions": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
       "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
-      "dev": true,
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/mongodb-connection-string-url/node_modules/whatwg-url": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-13.0.0.tgz",
-      "integrity": "sha512-9WWbymnqj57+XEuqADHrCJ2eSXzn8WXIW/YSGaZtb2WKAInQ6CHfaUUcTyyver0p8BDg5StLQq8h1vtZuwmOig==",
-      "dev": true,
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "license": "MIT",
       "dependencies": {
-        "tr46": "^4.1.1",
+        "tr46": "^5.1.0",
         "webidl-conversions": "^7.0.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/mongodb-download-url": {
@@ -9322,18 +9266,18 @@
       }
     },
     "node_modules/mongodb-runner": {
-      "version": "6.7.7",
-      "resolved": "https://registry.npmjs.org/mongodb-runner/-/mongodb-runner-6.7.7.tgz",
-      "integrity": "sha512-ZfGBEeY6v7ILObrkKCjR4TozC3TVLK7uAulUk2JX3FFaC88hcNT/mgdgabRfw0lE+Plry9J/vawn5ysv8r2TTg==",
+      "version": "6.8.3",
+      "resolved": "https://registry.npmjs.org/mongodb-runner/-/mongodb-runner-6.8.3.tgz",
+      "integrity": "sha512-xASPTQ8z0qflAFMHPwWg97cUztQuXLT8th/ZDuqRymK9j+9xBv5BCNxAQY/UMKYqAx6dd2/YlsqMtCHuX2SIkw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@mongodb-js/mongodb-downloader": "^1.1.11",
-        "@mongodb-js/oidc-mock-provider": "^0.13.9",
-        "@mongodb-js/saslprep": "^1.4.8",
+        "@mongodb-js/mongodb-downloader": "^1.1.16",
+        "@mongodb-js/oidc-mock-provider": "^0.13.13",
+        "@mongodb-js/saslprep": "^1.4.12",
         "@peculiar/x509": "^2.0.0",
         "debug": "^4.4.0",
-        "mongodb": "^6.9.0 || ^7.0.0",
+        "mongodb": "^7.2.0",
         "mongodb-connection-string-url": "^3.0.0 || ^7.0.0",
         "reflect-metadata": "^0.2.2",
         "yargs": "^18.0.0"
@@ -12135,22 +12079,6 @@
         "@node-rs/bcrypt": "1.10.7"
       }
     },
-    "node_modules/parse-server/node_modules/@types/whatwg-url": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-13.0.0.tgz",
-      "integrity": "sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q==",
-      "dependencies": {
-        "@types/webidl-conversions": "*"
-      }
-    },
-    "node_modules/parse-server/node_modules/bson": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-7.2.0.tgz",
-      "integrity": "sha512-YCEo7KjMlbNlyHhz7zAZNDpIpQbd+wOEHJYezv0nMYTn4x31eIUM2yomNNubclAt63dObUzKHWsBLJ9QcZNSnQ==",
-      "engines": {
-        "node": ">=20.19.0"
-      }
-    },
     "node_modules/parse-server/node_modules/gaxios": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
@@ -12234,18 +12162,6 @@
         }
       }
     },
-    "node_modules/parse-server/node_modules/mongodb-connection-string-url": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-7.0.1.tgz",
-      "integrity": "sha512-h0AZ9A7IDVwwHyMxmdMXKy+9oNlF0zFoahHiX3vQ8e3KFcSP3VmsmfvtRSuLPxmyv2vjIDxqty8smTgie/SNRQ==",
-      "dependencies": {
-        "@types/whatwg-url": "^13.0.0",
-        "whatwg-url": "^14.1.0"
-      },
-      "engines": {
-        "node": ">=20.19.0"
-      }
-    },
     "node_modules/parse-server/node_modules/node-fetch": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
@@ -12275,37 +12191,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/parse-server/node_modules/tr46": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
-      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
-      "dependencies": {
-        "punycode": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/parse-server/node_modules/webidl-conversions": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/parse-server/node_modules/whatwg-url": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
-      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
-      "dependencies": {
-        "tr46": "^5.1.0",
-        "webidl-conversions": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/parse5": {
@@ -18511,10 +18396,9 @@
       "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA=="
     },
     "@types/whatwg-url": {
-      "version": "11.0.5",
-      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
-      "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
-      "dev": true,
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-13.0.0.tgz",
+      "integrity": "sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q==",
       "requires": {
         "@types/webidl-conversions": "*"
       }
@@ -18994,10 +18878,9 @@
       }
     },
     "bson": {
-      "version": "6.10.4",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.4.tgz",
-      "integrity": "sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng==",
-      "dev": true
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-7.3.1.tgz",
+      "integrity": "sha512-h/C0qe6857pQhcSJHLfsR1uYGj98Ge3wKAD3Ed9KqH3wcVh+BM4Jq4xISD7vs9OPuT07n+q3QQVjslJ286j6ag=="
     },
     "buffer": {
       "version": "5.7.1",
@@ -20714,57 +20597,6 @@
         }
       }
     },
-    "gcp-metadata": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-5.3.0.tgz",
-      "integrity": "sha512-FNTkdNEnBdlqF2oatizolQqNANMrcqJt6AAYt99B3y1aLLC8Hc5IOBb+ZnnzllodEEf6xMBp6wRcBbc16fa65w==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "gaxios": "^5.0.0",
-        "json-bigint": "^1.0.0"
-      },
-      "dependencies": {
-        "agent-base": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-          "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-          "dev": true,
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "debug": "4"
-          }
-        },
-        "gaxios": {
-          "version": "5.1.3",
-          "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-5.1.3.tgz",
-          "integrity": "sha512-95hVgBRgEIRQQQHIbnxBXeHbW4TqFk4ZDJW7wmVtvYar72FdhRIo1UGOLS2eRAKCPEdPBWu+M7+A33D9CdX9rA==",
-          "dev": true,
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "extend": "^3.0.2",
-            "https-proxy-agent": "^5.0.0",
-            "is-stream": "^2.0.0",
-            "node-fetch": "^2.6.9"
-          }
-        },
-        "https-proxy-agent": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-          "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-          "dev": true,
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "agent-base": "6",
-            "debug": "4"
-          }
-        }
-      }
-    },
     "gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -22057,48 +21889,44 @@
       "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how=="
     },
     "mongodb": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.20.0.tgz",
-      "integrity": "sha512-Tl6MEIU3K4Rq3TSHd+sZQqRBoGlFsOgNrH5ltAcFBV62Re3Fd+FcaVf8uSEQFOJ51SDowDVttBTONMfoYWrWlQ==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-7.5.0.tgz",
+      "integrity": "sha512-5FnrEDLnvp6ycUOGLNLLU33BfCx2qmp2mJjGPDwKLruYsVzXVSK5fsGpoDXvsXJwBfBsD7ebMRdawbDxC2814g==",
       "dev": true,
       "requires": {
-        "@mongodb-js/saslprep": "^1.3.0",
-        "bson": "^6.10.4",
-        "mongodb-connection-string-url": "^3.0.2"
+        "@mongodb-js/saslprep": "^1.4.11",
+        "bson": "^7.2.0",
+        "mongodb-connection-string-url": "^7.0.1"
       }
     },
     "mongodb-connection-string-url": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.2.tgz",
-      "integrity": "sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==",
-      "dev": true,
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-7.0.2.tgz",
+      "integrity": "sha512-ZoS07RoFqpKYQwAk59qmrx8+jJHNHU30UjlU96QktiGn1ltvDr+vCznLX5DiUBLEpMAHatHNWV1nM/74ul66kA==",
       "requires": {
-        "@types/whatwg-url": "^11.0.2",
-        "whatwg-url": "^14.1.0 || ^13.0.0"
+        "@types/whatwg-url": "^13.0.0",
+        "whatwg-url": "^14.1.0"
       },
       "dependencies": {
         "tr46": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
-          "integrity": "sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==",
-          "dev": true,
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+          "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
           "requires": {
-            "punycode": "^2.3.0"
+            "punycode": "^2.3.1"
           }
         },
         "webidl-conversions": {
           "version": "7.0.0",
           "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-          "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
-          "dev": true
+          "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="
         },
         "whatwg-url": {
-          "version": "13.0.0",
-          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-13.0.0.tgz",
-          "integrity": "sha512-9WWbymnqj57+XEuqADHrCJ2eSXzn8WXIW/YSGaZtb2WKAInQ6CHfaUUcTyyver0p8BDg5StLQq8h1vtZuwmOig==",
-          "dev": true,
+          "version": "14.2.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+          "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
           "requires": {
-            "tr46": "^4.1.1",
+            "tr46": "^5.1.0",
             "webidl-conversions": "^7.0.0"
           }
         }
@@ -22125,17 +21953,17 @@
       }
     },
     "mongodb-runner": {
-      "version": "6.7.7",
-      "resolved": "https://registry.npmjs.org/mongodb-runner/-/mongodb-runner-6.7.7.tgz",
-      "integrity": "sha512-ZfGBEeY6v7ILObrkKCjR4TozC3TVLK7uAulUk2JX3FFaC88hcNT/mgdgabRfw0lE+Plry9J/vawn5ysv8r2TTg==",
+      "version": "6.8.3",
+      "resolved": "https://registry.npmjs.org/mongodb-runner/-/mongodb-runner-6.8.3.tgz",
+      "integrity": "sha512-xASPTQ8z0qflAFMHPwWg97cUztQuXLT8th/ZDuqRymK9j+9xBv5BCNxAQY/UMKYqAx6dd2/YlsqMtCHuX2SIkw==",
       "dev": true,
       "requires": {
-        "@mongodb-js/mongodb-downloader": "^1.1.11",
-        "@mongodb-js/oidc-mock-provider": "^0.13.9",
-        "@mongodb-js/saslprep": "^1.4.8",
+        "@mongodb-js/mongodb-downloader": "^1.1.16",
+        "@mongodb-js/oidc-mock-provider": "^0.13.13",
+        "@mongodb-js/saslprep": "^1.4.12",
         "@peculiar/x509": "^2.0.0",
         "debug": "^4.4.0",
-        "mongodb": "^6.9.0 || ^7.0.0",
+        "mongodb": "^7.2.0",
         "mongodb-connection-string-url": "^3.0.0 || ^7.0.0",
         "reflect-metadata": "^0.2.2",
         "yargs": "^18.0.0"
@@ -23983,19 +23811,6 @@
         "ws": "8.20.0"
       },
       "dependencies": {
-        "@types/whatwg-url": {
-          "version": "13.0.0",
-          "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-13.0.0.tgz",
-          "integrity": "sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q==",
-          "requires": {
-            "@types/webidl-conversions": "*"
-          }
-        },
-        "bson": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/bson/-/bson-7.2.0.tgz",
-          "integrity": "sha512-YCEo7KjMlbNlyHhz7zAZNDpIpQbd+wOEHJYezv0nMYTn4x31eIUM2yomNNubclAt63dObUzKHWsBLJ9QcZNSnQ=="
-        },
         "gaxios": {
           "version": "7.1.4",
           "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
@@ -24035,15 +23850,6 @@
             "mongodb-connection-string-url": "^7.0.0"
           }
         },
-        "mongodb-connection-string-url": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-7.0.1.tgz",
-          "integrity": "sha512-h0AZ9A7IDVwwHyMxmdMXKy+9oNlF0zFoahHiX3vQ8e3KFcSP3VmsmfvtRSuLPxmyv2vjIDxqty8smTgie/SNRQ==",
-          "requires": {
-            "@types/whatwg-url": "^13.0.0",
-            "whatwg-url": "^14.1.0"
-          }
-        },
         "node-fetch": {
           "version": "3.3.2",
           "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
@@ -24060,28 +23866,6 @@
           "version": "7.7.4",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
           "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="
-        },
-        "tr46": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
-          "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
-          "requires": {
-            "punycode": "^2.3.1"
-          }
-        },
-        "webidl-conversions": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-          "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="
-        },
-        "whatwg-url": {
-          "version": "14.2.0",
-          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
-          "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
-          "requires": {
-            "tr46": "^5.1.0",
-            "webidl-conversions": "^7.0.0"
-          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "eslint": "10.2.1",
     "globals": "17.5.0",
     "jasmine": "6.2.0",
-    "mongodb-runner": "6.7.7",
+    "mongodb-runner": "6.8.3",
     "nodemon": "3.1.14",
     "nyc": "18.0.0",
     "prettier": "3.8.3",


### PR DESCRIPTION
Closes #909

Replacement for the Dependabot PR, bumping the direct devDependency `mongodb-runner` from `6.7.7` to `6.8.3`.

### Changes
- Bumps `mongodb-runner` from `6.7.7` to `6.8.3` (routine minor update of a direct devDependency).
- `package.json` and `package-lock.json` updated only; the lockfile deletions are npm hoisting/deduplicating `mongodb-runner`'s transitive dependencies (mongodb, bson, mongodb-connection-string-url, whatwg-url, etc.), which now also satisfy `parse-server`'s nested copies.

### Breaking Changes
- None. `mongodb-runner` is a test-only devDependency; runtime dependencies are unaffected.

### Code Changes Required
- None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the MongoDB test tooling to a newer version.
  * Refreshed MongoDB-related packages and supporting dependencies in the lockfile.
  * Updated package requirements to align with newer runtime compatibility standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->