### PR TITLE
refactor: Bump @types/node from 25.6.0 to 26.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@semantic-release/npm": "13.1.5",
         "@semantic-release/release-notes-generator": "14.1.0",
         "@types/jasmine": "6.0.0",
-        "@types/node": "25.6.0",
+        "@types/node": "26.1.1",
         "@types/parse": "6.1.0",
         "cross-env": "10.1.0",
         "eslint": "10.7.0",
@@ -3966,12 +3966,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.19.0"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@types/normalize-package-data": {
@@ -14992,9 +14992,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "license": "MIT"
     },
     "node_modules/unicode-emoji-modifier-base": {
@@ -18308,11 +18308,11 @@
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="
     },
     "@types/node": {
-      "version": "25.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
       "requires": {
-        "undici-types": "~7.19.0"
+        "undici-types": "~8.3.0"
       }
     },
     "@types/normalize-package-data": {
@@ -25855,9 +25855,9 @@
       "dev": true
     },
     "undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="
     },
     "unicode-emoji-modifier-base": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@semantic-release/npm": "13.1.5",
     "@semantic-release/release-notes-generator": "14.1.0",
     "@types/jasmine": "6.0.0",
-    "@types/node": "25.6.0",
+    "@types/node": "26.1.1",
     "@types/parse": "6.1.0",
     "cross-env": "10.1.0",
     "eslint": "10.7.0",


### PR DESCRIPTION
Closes #907

## Changes
Bumps the direct devDependency [`@types/node`](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/HEAD/types/node) from `25.6.0` to `26.1.1` (major version bump, `25` -> `26`). This package provides TypeScript type definitions for Node.js and has no runtime footprint. Its transitive dependency `undici-types` updates accordingly (`~7.19.0` -> `~8.3.0`).

## Breaking Changes
None affecting this repository. `@types/node` is type-definitions-only, so a major bump can only break the build via changed/removed type definitions referenced by the project's own code. The project type-checks cleanly with the new version:

- `npx tsc --noEmit` produces identical output before and after the bump (one pre-existing, unrelated `TS5107` `moduleResolution` deprecation notice in `tsconfig.json`; no new errors).
- `tsconfig.json` sets `skipLibCheck: true`, so declaration files are not deeply type-checked.
- The bump replaces the previous `@types/node` major (Node 25 typings) with Node 26 typings; the repo's `engines` still target Node 18/20/22 and this is unaffected since these are types only.

## Code Changes
None. Only `package.json` and `package-lock.json` are modified; the lockfile diff is confined to `@types/node` and its transitive `undici-types`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Node.js type definitions to the latest version.
  * Refreshed related dependency metadata for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->