### PR TITLE
refactor: Bump jasmine from 6.2.0 to 6.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "cross-env": "10.1.0",
         "eslint": "10.7.0",
         "globals": "17.5.0",
-        "jasmine": "6.2.0",
+        "jasmine": "6.3.0",
         "mongodb-runner": "6.8.3",
         "nodemon": "3.1.14",
         "nyc": "18.0.0",
@@ -8410,24 +8410,24 @@
       }
     },
     "node_modules/jasmine": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-6.2.0.tgz",
-      "integrity": "sha512-dvYt7bidcu0JvvSbiUnSDW7UQQiflUwDr6C+5wzoZ0J7RY9u+UcoSIzyhMPj6fnU/tC7KinJ5QrjwD2Y9p4T4w==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-6.3.0.tgz",
+      "integrity": "sha512-u6L7yYtrtS1JALlp7f4k7Wz7o7ZKXauSKKkXc0L3qUkKrdaxYvNiMHhHp5gtTuVZZXVihXRxS7bWwDBX1wJ7EQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jasminejs/reporters": "^1.0.0",
         "glob": "^10.2.2 || ^11.0.3 || ^12.0.0 || ^13.0.0",
-        "jasmine-core": "~6.2.0"
+        "jasmine-core": "~6.3.0"
       },
       "bin": {
         "jasmine": "bin/jasmine.js"
       }
     },
     "node_modules/jasmine-core": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-6.2.0.tgz",
-      "integrity": "sha512-b16WZG/pFEFj8qRW1ss7nDuNGYz9ji8BDGj7fJNrROauk5rj/diO3KPOuyIpcgUChdC+c0PfQ8iUk4nHE+EN4w==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-6.3.0.tgz",
+      "integrity": "sha512-eMm5qBovNjNoGOcgE/W207+wrcK5zrQv0Rg/rWGboUJUmZp0dFCpHTyjpuDAfCwRCqg7f9U2q2jtv/aUuzdCQg==",
       "dev": true,
       "license": "MIT"
     },
@@ -21338,20 +21338,20 @@
       }
     },
     "jasmine": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-6.2.0.tgz",
-      "integrity": "sha512-dvYt7bidcu0JvvSbiUnSDW7UQQiflUwDr6C+5wzoZ0J7RY9u+UcoSIzyhMPj6fnU/tC7KinJ5QrjwD2Y9p4T4w==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-6.3.0.tgz",
+      "integrity": "sha512-u6L7yYtrtS1JALlp7f4k7Wz7o7ZKXauSKKkXc0L3qUkKrdaxYvNiMHhHp5gtTuVZZXVihXRxS7bWwDBX1wJ7EQ==",
       "dev": true,
       "requires": {
         "@jasminejs/reporters": "^1.0.0",
         "glob": "^10.2.2 || ^11.0.3 || ^12.0.0 || ^13.0.0",
-        "jasmine-core": "~6.2.0"
+        "jasmine-core": "~6.3.0"
       }
     },
     "jasmine-core": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-6.2.0.tgz",
-      "integrity": "sha512-b16WZG/pFEFj8qRW1ss7nDuNGYz9ji8BDGj7fJNrROauk5rj/diO3KPOuyIpcgUChdC+c0PfQ8iUk4nHE+EN4w==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-6.3.0.tgz",
+      "integrity": "sha512-eMm5qBovNjNoGOcgE/W207+wrcK5zrQv0Rg/rWGboUJUmZp0dFCpHTyjpuDAfCwRCqg7f9U2q2jtv/aUuzdCQg==",
       "dev": true
     },
     "java-properties": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "cross-env": "10.1.0",
     "eslint": "10.7.0",
     "globals": "17.5.0",
-    "jasmine": "6.2.0",
+    "jasmine": "6.3.0",
     "mongodb-runner": "6.8.3",
     "nodemon": "3.1.14",
     "nyc": "18.0.0",


### PR DESCRIPTION
Closes #918

## Changes
Bumps the `jasmine` devDependency from `6.2.0` to `6.3.0`, replacing the Dependabot PR with a `refactor:`-prefixed commit. Only `package.json` and `package-lock.json` are touched; the lockfile changes are confined to the `jasmine`/`jasmine-core` subtree.

## Breaking
None. This is a routine patch/minor-level bump of a test-only dependency with no breaking changes.

## Code-Changes
No source code changes required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Jasmine testing tools to version 6.3.0.
  * Refreshed the associated package metadata and lockfile entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->