### PR TITLE
refactor: Bump globals from 17.5.0 to 17.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@types/parse": "6.1.0",
         "cross-env": "10.1.0",
         "eslint": "10.7.0",
-        "globals": "17.5.0",
+        "globals": "17.7.0",
         "jasmine": "6.3.0",
         "mongodb-runner": "6.8.3",
         "nodemon": "3.1.14",
@@ -7452,9 +7452,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.5.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.5.0.tgz",
-      "integrity": "sha512-qoV+HK2yFl/366t2/Cb3+xxPUo5BuMynomoDmiaZBIdbs+0pYbjfZU+twLhGKp4uCZ/+NbtpVepH5bGCxRyy2g==",
+      "version": "17.7.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
+      "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -20691,9 +20691,9 @@
       }
     },
     "globals": {
-      "version": "17.5.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.5.0.tgz",
-      "integrity": "sha512-qoV+HK2yFl/366t2/Cb3+xxPUo5BuMynomoDmiaZBIdbs+0pYbjfZU+twLhGKp4uCZ/+NbtpVepH5bGCxRyy2g==",
+      "version": "17.7.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
+      "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
       "dev": true
     },
     "google-auth-library": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@types/parse": "6.1.0",
     "cross-env": "10.1.0",
     "eslint": "10.7.0",
-    "globals": "17.5.0",
+    "globals": "17.7.0",
     "jasmine": "6.3.0",
     "mongodb-runner": "6.8.3",
     "nodemon": "3.1.14",


### PR DESCRIPTION
Closes #920

## Summary

Bumps [globals](https://github.com/sindresorhus/globals) from 17.5.0 to 17.7.0. This is a direct devDependency used to provide the list of global identifiers for the ESLint configuration.

## Changes

- `package.json`: `globals` devDependency bumped `17.5.0` -> `17.7.0` (exact pin).
- `package-lock.json`: lockfile updated for the `globals` subtree only.

## Notes

Routine minor version update. No changes outside the `globals` subtree.
