### PR TITLE
refactor: Bump prettier from 3.8.3 to 3.9.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "mongodb-runner": "6.8.3",
         "nodemon": "3.1.14",
         "nyc": "18.0.0",
-        "prettier": "3.8.3",
+        "prettier": "3.9.6",
         "semantic-release": "25.0.3",
         "tsx": "4.23.1",
         "typescript": "6.0.3",
@@ -12730,9 +12730,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
-      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -24251,9 +24251,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
-      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
       "dev": true
     },
     "pretty-ms": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "mongodb-runner": "6.8.3",
     "nodemon": "3.1.14",
     "nyc": "18.0.0",
-    "prettier": "3.8.3",
+    "prettier": "3.9.6",
     "semantic-release": "25.0.3",
     "tsx": "4.23.1",
     "typescript": "6.0.3",


### PR DESCRIPTION
Closes #928

## Summary
Bumps `prettier` from 3.8.3 to 3.9.6 (direct devDependency). Replacement PR for the Dependabot bump, opened from a fork branch.

## Changes
- `package.json`: `prettier` devDependency `3.8.3` -> `3.9.6` (exact)
- `package-lock.json`: regenerated prettier entry only

## Notes
- Patch/minor range within 3.x; no breaking changes expected for a formatter dev tool.
- Lockfile churn confined to the `prettier` subtree; `lockfileVersion` preserved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project’s formatting tool to a newer version.
  * Refreshed the associated package lock information for consistent installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->