### PR TITLE
refactor: Bump parse-server from 9.9.0 to 9.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "express": "5.2.1",
         "parse": "8.6.0",
-        "parse-server": "9.9.0"
+        "parse-server": "9.10.0"
       },
       "devDependencies": {
         "@eslint/js": "10.0.1",
@@ -12035,9 +12035,9 @@
       }
     },
     "node_modules/parse-server": {
-      "version": "9.9.0",
-      "resolved": "https://registry.npmjs.org/parse-server/-/parse-server-9.9.0.tgz",
-      "integrity": "sha512-r3MpxphR40G7Jgpb4H40ElXj4bEoC/5WNV3hqE13+XZG7ZLl6pATEzF6GjQwvM2421m2MHsvqGl34BxsVtURqg==",
+      "version": "9.10.0",
+      "resolved": "https://registry.npmjs.org/parse-server/-/parse-server-9.10.0.tgz",
+      "integrity": "sha512-f4IIsWLsh30mOJl6u6SB3GBrj7Zj4f69dKkI0PPZxNeVttlKFBEg/VHc2AQrWKWRvnIlWy22o2UdX4ECPDPCIw==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -23776,9 +23776,9 @@
       "dev": true
     },
     "parse-server": {
-      "version": "9.9.0",
-      "resolved": "https://registry.npmjs.org/parse-server/-/parse-server-9.9.0.tgz",
-      "integrity": "sha512-r3MpxphR40G7Jgpb4H40ElXj4bEoC/5WNV3hqE13+XZG7ZLl6pATEzF6GjQwvM2421m2MHsvqGl34BxsVtURqg==",
+      "version": "9.10.0",
+      "resolved": "https://registry.npmjs.org/parse-server/-/parse-server-9.10.0.tgz",
+      "integrity": "sha512-f4IIsWLsh30mOJl6u6SB3GBrj7Zj4f69dKkI0PPZxNeVttlKFBEg/VHc2AQrWKWRvnIlWy22o2UdX4ECPDPCIw==",
       "requires": {
         "@apollo/server": "5.5.0",
         "@as-integrations/express5": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "express": "5.2.1",
     "parse": "8.6.0",
-    "parse-server": "9.9.0"
+    "parse-server": "9.10.0"
   },
   "type": "module",
   "devDependencies": {


### PR DESCRIPTION
Closes #927

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Parse Server dependency to version 9.10.0.
  * Refreshed the locked dependency metadata to match the new version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->